### PR TITLE
Star domain rule `*.x` must match `x` itself, not just `y.x`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6,7 +6,7 @@ dependencies = [
  "argparse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "assert_matches 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "blake2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "digest-writer 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -16,7 +16,7 @@ dependencies = [
  "httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "httpbin 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "libcantal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -27,6 +27,7 @@ dependencies = [
  "quick-error 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quire 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "self-meter-http 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -36,7 +37,7 @@ dependencies = [
  "sha1 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "string-intern 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "tk-bufstream 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tk-http 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tk-listen 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -85,7 +86,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "atomic"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -106,7 +107,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "byteorder"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -114,13 +115,13 @@ name = "bytes"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cfg-if"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -250,7 +251,7 @@ dependencies = [
  "netbuf 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.8.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)",
  "tk-bufstream 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tk-http 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tk-listen 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -281,7 +282,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "unicode-bidi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -290,7 +291,7 @@ name = "iovec"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -325,7 +326,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.24"
+version = "0.2.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -333,8 +334,8 @@ name = "libcantal"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "atomic 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atomic 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -356,7 +357,7 @@ name = "memchr"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -364,7 +365,7 @@ name = "memchr"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -394,7 +395,7 @@ dependencies = [
  "iovec 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "miow 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.29 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -418,9 +419,9 @@ name = "net2"
 version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cfg-if 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "ws2_32-sys 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -458,7 +459,7 @@ name = "num_cpus"
 version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -534,12 +535,12 @@ name = "rand"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.19"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -591,7 +592,7 @@ name = "self-meter"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -712,7 +713,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -734,12 +735,12 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.1.37"
+version = "0.1.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -759,7 +760,7 @@ name = "tk-http"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -780,7 +781,7 @@ name = "tk-http"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -826,7 +827,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "futures 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)",
  "quick-error 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -872,7 +873,7 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -951,12 +952,12 @@ dependencies = [
 "checksum aho-corasick 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)" = "500909c4f87a9e52355b26626d890833e9e1d53ac566db76c36faa984b889699"
 "checksum argparse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "37bb99f5e39ee8b23b6e227f5b8f024207e8616f44aa4b8c76ecd828011667ef"
 "checksum assert_matches 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9e772942dccdf11b368c31e044e4fca9189f80a773d2f0808379de65894cbf57"
-"checksum atomic 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "81e4fe666ae9dd4eea17160116a5f0d1e52f74504669bfc034e22850d6b7d406"
+"checksum atomic 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6945bb928733f277215e12824ca9e31ce2016b6231dfc4816ed877df189cc17e"
 "checksum blake2 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "efbab0ff0c79c07dab12a3fdeb5175c8b1513266bb17657de00815123ea4f981"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
-"checksum byteorder 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c40977b0ee6b9885c9013cd41d9feffdd22deb3bb4dc3a71d901cc7a77de18c8"
+"checksum byteorder 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ff81738b726f5d099632ceaffe7fb65b90212e8dce59d518729e7e8634032d3d"
 "checksum bytes 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8b24f16593f445422331a5eed46b72f7f171f910fead4f2ea8f17e727e9c5c14"
-"checksum cfg-if 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d0c47d456a36ebf0536a6705c83c1cbbcb9255fbc1d905a6ded104f479268a29"
+"checksum cfg-if 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "d4c819a1287eb618df47cc647173c5c4c66ba19d888a6e50d605672aed3140de"
 "checksum constant_time_eq 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "07dcb7959f0f6f1cf662f9a7ff389bcb919924d99ac41cf31f10d611d8721323"
 "checksum crypto-mac 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "779015233ac67d65098614aec748ac1c756ab6677fa2e14cf8b37c08dfed1198"
 "checksum digest 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "867593eac3ccb902465375ee94401490009054da278d4bb2f11a6f8b5bfeca98"
@@ -982,7 +983,7 @@ dependencies = [
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "3b37545ab726dd833ec6420aaba8231c5b320814b9029ad585555d2a03e94fbf"
 "checksum lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ce12306c4739d86ee97c23139f3a34ddf0387bbf181bc7929d287025a8c3ef6b"
-"checksum libc 0.2.24 (registry+https://github.com/rust-lang/crates.io-index)" = "38f5c2b18a287cf78b4097db62e20f43cace381dc76ae5c0a3073067f78b7ddc"
+"checksum libc 0.2.26 (registry+https://github.com/rust-lang/crates.io-index)" = "30885bcb161cf67054244d10d4a7f4835ffd58773bc72e07d35fecf472295503"
 "checksum libcantal 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "15300d31290401cf778a2c90d5bc5dc2cf2917d03e3c5f792a6fe96ec3d51a7e"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
@@ -1008,7 +1009,7 @@ dependencies = [
 "checksum quire 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "7d4565e5a8929f805844de74a6c4a72c73ddba1036f602e5e36b7faa3b32c3fe"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum rand 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "022e0636ec2519ddae48154b028864bdce4eaf7d35226ab8e65c611be97b189d"
-"checksum redox_syscall 0.1.19 (registry+https://github.com/rust-lang/crates.io-index)" = "e4a357d14a12e90a37d658725df0e6468504750b5948b9710f83f94a0c5818e8"
+"checksum redox_syscall 0.1.24 (registry+https://github.com/rust-lang/crates.io-index)" = "9aa093607d28cfd65f317edeeefb6749be428eacc8decd1c5f8c0fbcc327aff5"
 "checksum regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)" = "4fd4ace6a8cf7860714a2c2280d6c1f7e6a413486c13298bbc86fd3da019402f"
 "checksum regex 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1731164734096285ec2a5ec7fea5248ae2f5485b3feeb0115af4fda2183b2d1b"
 "checksum regex-syntax 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "f9ec002c35e86791825ed294b50008eea9ddfc8def4420124fbc6b08db834957"
@@ -1032,7 +1033,7 @@ dependencies = [
 "checksum thread-id 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a9539db560102d1cef46b8b78ce737ff0bb64e7e18d35b2a5688f7d097d0ff03"
 "checksum thread_local 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "8576dbbfcaef9641452d5cf0df9b0e7eeab7694956dd33bb61515fb8f18cfdd5"
 "checksum thread_local 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "1697c4b57aeeb7a536b647165a2825faddffb1d3bad386d507709bd51a90bb14"
-"checksum time 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "ffd7ccbf969a892bf83f1e441126968a07a3941c24ff522a26af9f9f4585d1a3"
+"checksum time 0.1.38 (registry+https://github.com/rust-lang/crates.io-index)" = "d5d788d3aa77bc0ef3e9621256885555368b47bd495c13dd2e7413c89f845520"
 "checksum tk-bufstream 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9bb87b067cbeb3362045e3f97e40ff3bd5b369bd1b23e6e8d308354534b83237"
 "checksum tk-http 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a7beae347472b250d889ad49cd9fa9034bfae9b1014057c3bd1c740533856122"
 "checksum tk-http 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9fde3f6b2493a5cb65cb3e4a2f48413bd5fbbb0ca137129b48a69a291a723ce2"
@@ -1043,7 +1044,7 @@ dependencies = [
 "checksum tokio-io 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c2c3ce9739f7387a0fa65b5421e81feae92e04d603f008898f4257790ce8c2db"
 "checksum typenum 1.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "13a99dc6780ef33c78780b826cf9d2a78840b72cae9474de4bcaf9051e60ebbd"
 "checksum unicase 1.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7f4765f83163b74f957c797ad9253caf97f103fb064d3999aea9568d09fc8a33"
-"checksum unicode-bidi 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a6a2c4e3710edd365cd7e78383153ed739fa31af19f9172f72d3575060f5a43a"
+"checksum unicode-bidi 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
 "checksum unicode-normalization 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "51ccda9ef9efa3f7ef5d91e8f9b83bbe6955f9bf86aec89d5cce2c874625920f"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ digest = "0.6.0"
 digest-writer = "0.2.0"
 generic-array = "0.8.2"
 typenum = "1.9.0"
+regex = "0.2.2"
 
 [[bin]]
 name = "swindon"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -231,7 +231,7 @@ pub mod test {
         let cfg = make_config();
 
         assert_eq!(cfg.listen.len(), 1);
-        assert_eq!(cfg.routing.num_hosts(), 3);
+        assert_eq!(cfg.routing.num_hosts(), 3+3);
         assert_eq!(cfg.handlers.len(), 7);
         assert_eq!(cfg.session_pools.len(), 1);
         assert_eq!(cfg.http_destinations.len(), 1);

--- a/src/config/read.rs
+++ b/src/config/read.rs
@@ -113,7 +113,7 @@ pub fn read_config<P: AsRef<Path>>(filename: P)
 
     // Extra config validations
 
-    for (route, sub) in cfg.routing.hosts() {
+    for &(ref route, ref sub) in cfg.routing.hosts() {
         for (path, name) in sub {
             if cfg.handlers.get(name).is_none() {
                 err!("Unknown handler for route: {:?} {:?}", route, name)
@@ -123,7 +123,7 @@ pub fn read_config<P: AsRef<Path>>(filename: P)
                      route, path, name);
             }
             if let Some(&Handler::StripWWWRedirect) = cfg.handlers.get(name) {
-                if !route.starts_with("www.") {
+                if !route.matches_www() {
                     err!(concat!("Expected `www.` prefix for StripWWWRedirect",
                                  " handler route: {:?} {:?}"), route, name);
                 }

--- a/src/main-dev.rs
+++ b/src/main-dev.rs
@@ -24,6 +24,7 @@ extern crate netbuf;
 extern crate ns_std_threaded;
 extern crate quire;
 extern crate rand;
+extern crate regex;
 extern crate rustc_serialize;
 extern crate self_meter_http;
 extern crate serde;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ extern crate netbuf;
 extern crate ns_std_threaded;
 extern crate quire;
 extern crate rand;
+extern crate regex;
 extern crate rustc_serialize;
 extern crate self_meter_http;
 extern crate serde;

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -76,8 +76,10 @@ impl PartialOrd for Host {
 impl Host {
     pub fn matches(&self, host: &str) -> bool {
         let h = self.0.as_str();
-        if h.starts_with("*.") {
-            host.ends_with(&h[1..])
+        if h == "*" {
+            return true;
+        } else if h.starts_with("*.") {
+            host.ends_with(&h[1..]) || host == &h[2..]
         } else {
             host == h
         }
@@ -248,8 +250,6 @@ mod route_test {
             ].into_iter().collect());
 
 
-        assert_eq!(route("test.example.com", "/hello", &table),
-                   None);
         assert_eq!(route("example.com", "/hello", &table),
                    Some((&1, "", "/hello")));
         assert_eq!(route("example.com", "/path", &table),
@@ -262,6 +262,8 @@ mod route_test {
                    Some((&3, "/path", "/hello")));
         assert_eq!(route("localhost", "/path", &table),
                    Some((&3, "/path", "")));
+        assert_eq!(route("test.example.com", "/hello", &table),
+                   None);
     }
 
     #[test]
@@ -349,7 +351,7 @@ mod parse_test {
         assert!(!h.matches("www.example.com"));
 
         let h = Host("*.example.com".into());
-        assert!(!h.matches("example.com"));
+        assert!(h.matches("example.com"));
         assert!(h.matches("xxx.example.com"));
         assert!(h.matches("www.example.com"));
     }

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -232,6 +232,39 @@ mod route_test {
     }
 
     #[test]
+    fn route_star() {
+        // Routing table
+        //   example.com: 1
+        //   *: 2
+        //   */path: 3
+        let table = RoutingTable(vec![
+            ("example.com".parse().unwrap(), vec![
+                (None, 1),
+                ].into_iter().collect()),
+            ("*".parse().unwrap(), vec![
+                (None, 2),
+                (Some("/path".into()), 3),
+                ].into_iter().collect()),
+            ].into_iter().collect());
+
+
+        assert_eq!(route("test.example.com", "/hello", &table),
+                   None);
+        assert_eq!(route("example.com", "/hello", &table),
+                   Some((&1, "", "/hello")));
+        assert_eq!(route("example.com", "/path", &table),
+                   Some((&1, "", "/path")));
+        assert_eq!(route("example.com", "/path/hello", &table),
+                   Some((&1, "", "/path/hello")));
+        assert_eq!(route("localhost", "/hello", &table),
+                   Some((&2, "", "/hello")));
+        assert_eq!(route("localhost", "/path/hello", &table),
+                   Some((&3, "/path", "/hello")));
+        assert_eq!(route("localhost", "/path", &table),
+                   Some((&3, "/path", "")));
+    }
+
+    #[test]
     fn route_path() {
         let table = RoutingTable(vec![
             ("ex.com".parse().unwrap(), vec![

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -225,6 +225,8 @@ mod route_test {
                    Some((&1, "", "/hello")));
         assert_eq!(route("xxx.aaa.example.com", "/hello", &table),
                    Some((&6, "", "/hello")));
+        assert_eq!(route("aaa.example.com", "/hello", &table),
+                   Some((&6, "", "/hello")));
         assert_eq!(route("city.example.com", "/static", &table),
                    Some((&3, "/static", "")));
     }

--- a/src/routing.rs
+++ b/src/routing.rs
@@ -1,30 +1,39 @@
-use std::cmp::{Ordering, PartialOrd, Ord};
-use std::collections::{BTreeMap, btree_map};
-use std::ops::Deref;
+use std::collections::{HashMap, BTreeMap};
 use std::str::FromStr;
 
+use regex::{self, RegexSet};
 use rustc_serialize::{Decoder, Decodable};
 
 
 pub type Path = Option<String>;
 
-#[derive(Debug, PartialEq, Eq)]
-pub struct RoutingTable<H>(BTreeMap<Host, BTreeMap<Path, H>>);
-
-#[derive(Debug, PartialEq, Eq)]
-pub struct Host(String);
-
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
-enum Match<'a> {
-    Word(&'a str),
-    Asterisk,
+#[derive(Debug)]
+pub struct RoutingTable<H> {
+    set: RegexSet,
+    table: Vec<(Host, BTreeMap<Path, H>)>,
 }
 
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct Host(bool, String);
+
+impl Host {
+    pub fn matches_www(&self) -> bool {
+        self.0 || self.1.starts_with("www.")
+    }
+}
+
+impl<H: PartialEq> PartialEq for RoutingTable<H> {
+    fn eq(&self, other: &RoutingTable<H>) -> bool {
+        return self.table == other.table;
+    }
+}
+
+impl<H: Eq> Eq for RoutingTable<H> {}
 
 impl<T: Decodable> Decodable for RoutingTable<T> {
     fn decode<D: Decoder>(d: &mut D) -> Result<Self, D::Error> {
         d.read_map(|mut d, n| {
-            let mut rv = BTreeMap::new();
+            let mut rv = HashMap::new();
             for idx in 0..n {
                 let (host, path) = d.read_map_elt_key(idx, |mut d| {
                     d.read_str().map(parse_host_path)
@@ -34,55 +43,54 @@ impl<T: Decodable> Decodable for RoutingTable<T> {
                 .or_insert_with(|| BTreeMap::new())
                 .insert(path, val);
             }
-            Ok(RoutingTable(rv))
+            RoutingTable::new(rv).map_err(|e| d.error(
+                &format!("Can't compile routing table: {}", e)))
         })
     }
 }
 
 impl<T> RoutingTable<T> {
-    pub fn hosts(&self) -> btree_map::Iter<Host, BTreeMap<Path, T>> {
-        self.0.iter()
+    pub fn new(mut items: HashMap<Host, BTreeMap<Path, T>>)
+        -> Result<RoutingTable<T>, regex::Error>
+    {
+        let mut to_insert = Vec::new();
+        for host in items.keys() {
+            if !host.0 {
+                let pat = Host(true, host.1.clone());
+                if !items.contains_key(&pat) {
+                    to_insert.push(pat);
+                }
+            }
+        }
+        for host in to_insert {
+            items.insert(host, BTreeMap::new());
+        }
+        let mut items: Vec<_> = items.into_iter().collect();
+        items.sort_by(|&(ref a, _), &(ref b, _)| b.1.len().cmp(&a.1.len())
+            .then_with(|| a.0.cmp(&b.0)));
+        let regex = RegexSet::new(
+            items.iter().map(|&(ref h, _)| {
+                if h.0 && h.1 == "" {
+                    String::from("^.*$")
+                } else if h.0 {
+                    String::from(r#"^(?:^|.*\.)"#) +
+                        &regex::escape(&h.1) + "$"
+                } else {
+                    String::from("^") + &regex::escape(&h.1) + "$"
+                }
+            })
+        )?;
+        Ok(RoutingTable {
+            set: regex,
+            table: items,
+        })
+    }
+    pub fn hosts(&self) -> ::std::slice::Iter<(Host, BTreeMap<Path, T>)> {
+        self.table.iter()
     }
     #[allow(dead_code)]
     pub fn num_hosts(&self) -> usize {
-        self.0.len()
-    }
-}
-
-impl<'a> Match<'a> {
-    fn new(val: &'a str) -> Match<'a> {
-        if val == "*" {
-            Match::Asterisk
-        } else {
-            Match::Word(val)
-        }
-    }
-}
-
-impl Ord for Host {
-    fn cmp(&self, other: &Host) -> Ordering {
-        let a = self.0.split('.').rev().map(Match::new);
-        let b = other.0.split('.').rev().map(Match::new);
-        a.cmp(b)
-    }
-}
-
-impl PartialOrd for Host {
-    fn partial_cmp(&self, other: &Host) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Host {
-    pub fn matches(&self, host: &str) -> bool {
-        let h = self.0.as_str();
-        if h == "*" {
-            return true;
-        } else if h.starts_with("*.") {
-            host.ends_with(&h[1..]) || host == &h[2..]
-        } else {
-            host == h
-        }
+        self.table.len()
     }
 }
 
@@ -90,18 +98,15 @@ impl FromStr for Host {
     type Err = ();
 
     fn from_str(val: &str) -> Result<Host, ()> {
-        Ok(Host(val.to_string()))
+        if val == "*" {
+            Ok(Host(true, String::from("")))
+        } else if val.starts_with("*.") {
+            Ok(Host(true, val[2..].to_string()))
+        } else {
+            Ok(Host(false, val.to_string()))
+        }
     }
 }
-
-impl Deref for Host {
-    type Target = String;
-
-    fn deref(&self) -> &String {
-        &self.0
-    }
-}
-
 
 fn parse_host_path(val: String) -> (Host, Path) {
     let (host, path) = if let Some(i) = val.find('/') {
@@ -123,18 +128,18 @@ pub fn route<'x, D>(host: &str, path: &'x str,
     table: &'x RoutingTable<D>)
     -> Option<(&'x D, &'x str, &'x str)>
 {
-    // TODO(tailhook) transform into range iteration when `btree_range` is
-    // stable
-    for (route_host, sub_table) in table.hosts() {
-        if route_host.matches(host) {
-            for (route_path, result) in sub_table.iter().rev() {
-                if path_match(&route_path, path) {
-                    // Longest match is the last in reversed iteration
-                    let prefix = route_path.as_ref().map(|x| &x[..]).unwrap_or("");
-                    return Some((result, prefix, &path[prefix.len()..]));
-                }
-            }
-            return None;
+    let set = table.set.matches(host);
+    if !set.matched_any() {
+        return None;
+    }
+    let idx = set.iter().next().unwrap();
+    let (_, ref sub_table) = table.table[idx];
+
+    for (route_path, result) in sub_table.iter().rev() {
+        if path_match(&route_path, path) {
+            // Longest match is the last in reversed iteration
+            let prefix = route_path.as_ref().map(|x| &x[..]).unwrap_or("");
+            return Some((result, prefix, &path[prefix.len()..]));
         }
     }
     return None;
@@ -167,17 +172,16 @@ pub fn parse_host(host_header: &str) -> &str {
 
 #[cfg(test)]
 mod route_test {
-    use super::{Host, Path};
     use super::route;
     use super::RoutingTable;
 
     #[test]
     fn route_host() {
-        let table = RoutingTable(vec![
+        let table = RoutingTable::new(vec![
             ("example.com".parse().unwrap(), vec![
                 (None, 1),
                 ].into_iter().collect()),
-            ].into_iter().collect());
+            ].into_iter().collect()).unwrap();
         assert_eq!(route("example.com", "/hello", &table),
                    Some((&1, "", "/hello")));
         assert_eq!(route("example.com", "/", &table),
@@ -195,7 +199,7 @@ mod route_test {
         //   www.example.com/static/favicon.ico: 4
         //   xxx.example.com: 5
         //   *.aaa.example.com: 6
-        let table = RoutingTable(vec![
+        let table = RoutingTable::new(vec![
             ("example.com".parse().unwrap(), vec![
                 (None, 1),
                 ].into_iter().collect()),
@@ -212,7 +216,7 @@ mod route_test {
             ("*.aaa.example.com".parse().unwrap(), vec![
                 (None, 6),
                 ].into_iter().collect()),
-            ].into_iter().collect());
+            ].into_iter().collect()).unwrap();
 
         assert_eq!(route("test.example.com", "/hello", &table),
                    Some((&2, "", "/hello")));
@@ -239,7 +243,7 @@ mod route_test {
         //   example.com: 1
         //   *: 2
         //   */path: 3
-        let table = RoutingTable(vec![
+        let table = RoutingTable::new(vec![
             ("example.com".parse().unwrap(), vec![
                 (None, 1),
                 ].into_iter().collect()),
@@ -247,7 +251,7 @@ mod route_test {
                 (None, 2),
                 (Some("/path".into()), 3),
                 ].into_iter().collect()),
-            ].into_iter().collect());
+            ].into_iter().collect()).unwrap();
 
 
         assert_eq!(route("example.com", "/hello", &table),
@@ -268,13 +272,13 @@ mod route_test {
 
     #[test]
     fn route_path() {
-        let table = RoutingTable(vec![
+        let table = RoutingTable::new(vec![
             ("ex.com".parse().unwrap(), vec![
                 (None , 0),
                 (Some("/one".into()), 1),
                 (Some("/two".into()) , 2),
                 ].into_iter().collect()),
-            ].into_iter().collect());
+            ].into_iter().collect()).unwrap();
         assert_eq!(route("ex.com", "/one", &table),
                    Some((&1, "/one", "")));
         assert_eq!(route("ex.com", "/one/end", &table),
@@ -297,14 +301,14 @@ mod route_test {
 
 #[cfg(test)]
 mod parse_test {
-    use super::{Host, Path};
+    use super::Host;
     use super::parse_host_path;
 
     #[test]
     fn simple() {
         let s = "example.com".to_string();
         let (host, path) = parse_host_path(s);
-        assert_eq!(host, Host("example.com".into()));
+        assert_eq!(host, Host(false, "example.com".into()));
         assert!(path.is_none());
     }
 
@@ -312,7 +316,7 @@ mod parse_test {
     fn base_host() {
         let s = "*.example.com".to_string();
         let (host, path) = parse_host_path(s);
-        assert_eq!(host, Host("*.example.com".into()));
+        assert_eq!(host, Host(true, "example.com".into()));
         assert!(path.is_none());
     }
 
@@ -320,12 +324,12 @@ mod parse_test {
     fn invalid_base_host() {
         let s = "*example.com".to_string();
         let (host, path) = parse_host_path(s);
-        assert_eq!(host, Host("*example.com".into()));
+        assert_eq!(host, Host(false, "*example.com".into()));
         assert!(path.is_none());
 
         let s = ".example.com".to_string();
         let (host, path) = parse_host_path(s);
-        assert_eq!(host, Host(".example.com".into()));
+        assert_eq!(host, Host(false, ".example.com".into()));
         assert!(path.is_none());
     }
 
@@ -334,53 +338,13 @@ mod parse_test {
         // FiXME: only dot is invalid
         let s = "*.".to_string();
         let (host, path) = parse_host_path(s);
-        assert_eq!(host, Host("*.".into()));
+        assert_eq!(host, Host(true, "".into()));
         assert!(path.is_none());
 
         let s = "*./".to_string();
         let (host, path) = parse_host_path(s);
-        assert_eq!(host, Host("*.".into()));
+        assert_eq!(host, Host(true, "".into()));
         assert!(path.is_none());
-    }
-
-    #[test]
-    fn match_host() {
-        let h = Host("example.com".into());
-        assert!(h.matches("example.com"));
-        assert!(!h.matches(".example.com"));
-        assert!(!h.matches("www.example.com"));
-
-        let h = Host("*.example.com".into());
-        assert!(h.matches("example.com"));
-        assert!(h.matches("xxx.example.com"));
-        assert!(h.matches("www.example.com"));
-    }
-
-    #[test]
-    fn ordering() {
-        let mut ordered: Vec<Host> = vec![
-            "aaa".parse().unwrap(),
-            "*.bbb".parse().unwrap(),
-            "*.aaa.bbb".parse().unwrap(),
-            "*.zzz.bbb".parse().unwrap(),
-            "aaa.zzz".parse().unwrap(),
-        ];
-        ordered.sort();
-        assert_eq!(ordered, [
-            Host("aaa".into()),
-            Host("*.aaa.bbb".into()),
-            Host("*.zzz.bbb".into()),
-            Host("*.bbb".into()),
-            Host("aaa.zzz".into()),
-        ]);
-        ordered.reverse();
-        assert_eq!(ordered, [
-            Host("aaa.zzz".into()),
-            Host("*.bbb".into()),
-            Host("*.zzz.bbb".into()),
-            Host("*.aaa.bbb".into()),
-            Host("aaa".into()),
-        ]);
     }
 
 }

--- a/tests/config_test.py
+++ b/tests/config_test.py
@@ -260,7 +260,7 @@ def test_www_redirect_route_prefix(check_config):
     """)
     assert (
         "Expected `www.` prefix for StripWWWRedirect handler route:"
-        " Host(\"example.com\")"
+        " Host(false, \"example.com\")"
         ) in err
 
 
@@ -272,6 +272,6 @@ def test_route_path_suffix(check_config):
             handler: !EmptyGif
     """)
     assert (
-        "Path must not end with /: Host(\"localhost\")"
+        "Path must not end with /: Host(false, \"localhost\")"
         " Some(\"/some/path/\") handler\"handler\""
         ) in err


### PR DESCRIPTION
Currently, this test breaks. And fixing it is a breaking change.

@popravich, should this be fixed?